### PR TITLE
Update index.js

### DIFF
--- a/__tests__/index.js
+++ b/__tests__/index.js
@@ -134,7 +134,7 @@ describe('WebMergePromiseAPI', () => {
 
       return api.getDataRoutes()
         .then(() => {
-          expect(api.client.get.mock.calls[0][0]).toEqual({ url: '/route' })
+          expect(api.client.get.mock.calls[0][0]).toEqual({ url: '/api/routes' })
         })
     })
   })
@@ -145,7 +145,7 @@ describe('WebMergePromiseAPI', () => {
 
       return api.getDataRoute(1)
         .then(() => {
-          expect(api.client.get.mock.calls[0][0]).toEqual({ url: '/route/1' })
+          expect(api.client.get.mock.calls[0][0]).toEqual({ url: '/api/routes/1' })
         })
     })
   })
@@ -156,7 +156,7 @@ describe('WebMergePromiseAPI', () => {
 
       return api.getDataRouteFields(1)
         .then(() => {
-          expect(api.client.get.mock.calls[0][0]).toEqual({ url: '/route/1/fields' })
+          expect(api.client.get.mock.calls[0][0]).toEqual({ url: '/api/routes/1/fields' })
         })
     })
   })
@@ -167,7 +167,7 @@ describe('WebMergePromiseAPI', () => {
 
       return api.getDataRouteRules(1)
         .then(() => {
-          expect(api.client.get.mock.calls[0][0]).toEqual({ url: '/route/1/rules' })
+          expect(api.client.get.mock.calls[0][0]).toEqual({ url: '/api/routes/1/rules' })
         })
     })
   })
@@ -179,7 +179,7 @@ describe('WebMergePromiseAPI', () => {
       return api.createDataRoute({ name: 'dummy route', rules: [{ document_id: 123456 }] })
         .then(() => {
           expect(api.client.post.mock.calls[0][0]).toEqual({
-            url: '/route',
+            url: '/api/routes',
             body: { name: 'dummy route', rules: [{ document_id: 123456 }] },
           })
         })
@@ -192,7 +192,7 @@ describe('WebMergePromiseAPI', () => {
 
       return api.updateDataRoute(1, {})
         .then(() => {
-          expect(api.client.put.mock.calls[0][0]).toEqual({ url: '/route/1', body: {} })
+          expect(api.client.put.mock.calls[0][0]).toEqual({ url: '/api/routes/1', body: {} })
         })
     })
   })
@@ -218,7 +218,7 @@ describe('WebMergePromiseAPI', () => {
 
       return api.deleteDataRoute(1)
         .then(() => {
-          expect(api.client.delete.mock.calls[0][0]).toEqual({ url: '/route/1' })
+          expect(api.client.delete.mock.calls[0][0]).toEqual({ url: '/api/routes/1' })
         })
     })
   })

--- a/index.js
+++ b/index.js
@@ -11,7 +11,8 @@ const request = require('request')
 const WEB_MERGE_BASE_URL = 'https://www.webmerge.me'
 const API_ENDPOINT = '/api/documents'
 const MERGE_ENDPOINT = '/merge'
-const ROUTE_ENDPOINT = '/route'
+const MERGE_ROUTE_ENDPOINT = '/route'
+const ROUTE_ENDPOINT = 'api/routes'
 const TOOLS_ENDPOINT = '/tools'
 
 

--- a/index.js
+++ b/index.js
@@ -237,7 +237,7 @@ class WebMergeAPI {
    */
   mergeDataRoute(id, key, data, isTestMode, downloadFile, callback) {
     return this.client.post({
-      url: `${ROUTE_ENDPOINT}/${id}/${key}`,
+      url: `${MERGE_ROUTE_ENDPOINT}/${id}/${key}`,
       qs: {
         test: isTestMode ? 1 : 0,
         download: downloadFile ? 1 : 0,

--- a/index.js
+++ b/index.js
@@ -12,7 +12,7 @@ const WEB_MERGE_BASE_URL = 'https://www.webmerge.me'
 const API_ENDPOINT = '/api/documents'
 const MERGE_ENDPOINT = '/merge'
 const MERGE_ROUTE_ENDPOINT = '/route'
-const ROUTE_ENDPOINT = 'api/routes'
+const ROUTE_ENDPOINT = '/api/routes'
 const TOOLS_ENDPOINT = '/tools'
 
 


### PR DESCRIPTION
It looks like webmerge changed the routes..... most of the routes for...."routes", use **api/routes** (similar to the api/documents).  The only one I think that stayed the same was the Merge Route (https://www.webmerge.me/developers/routes).  That's all I've changed here, 

const MERGE_ROUTE_ENDPOINT = '/route'
const ROUTE_ENDPOINT = '/api/routes'

and reflected that in the mergeDataRoute function